### PR TITLE
Add Biur Chametz event and Omer word data to API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.4.4",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@hebcal/core": "^6.1.0",
+        "@hebcal/core": "^6.3.0",
         "@hebcal/hdate": "^0.22.0",
         "@hebcal/leyning": "^9.5.2"
       },
@@ -332,9 +332,9 @@
       }
     },
     "node_modules/@hebcal/core": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@hebcal/core/-/core-6.1.0.tgz",
-      "integrity": "sha512-YrEOXTYh9vpswQeUPPujbI1ZeUjREg8GWY2tlAWMN7YxmUin1mrbaGf2PhNIB6ZR0UyUxlXUxpWDlYdh0cv50A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@hebcal/core/-/core-6.3.0.tgz",
+      "integrity": "sha512-QCwdSMg6SZzgRRqb+7ciD30wfjnqqiJ+NsYgccI/FaG2Ei8t0OXlIzLOBSN5KTEukajjebwjDW/G2Pg/cYpvrQ==",
       "license": "GPL-2.0",
       "dependencies": {
         "@hebcal/hdate": "^0.22.0",
@@ -1405,7 +1405,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1466,7 +1465,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -1794,7 +1792,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2241,7 +2238,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2318,7 +2314,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -4007,7 +4002,6 @@
       "integrity": "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4312,7 +4306,6 @@
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4802,8 +4795,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4861,7 +4853,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4935,7 +4926,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://hebcal.github.io/api/rest-api/",
   "dependencies": {
-    "@hebcal/core": "^6.1.0",
+    "@hebcal/core": "^6.3.0",
     "@hebcal/hdate": "^0.22.0",
     "@hebcal/leyning": "^9.5.2"
   },

--- a/src/classic-rest-api.ts
+++ b/src/classic-rest-api.ts
@@ -44,6 +44,9 @@ export type ClassicApiItem = {
       translit: string;
       en: string;
     };
+    anaBekoachWord: string;
+    lamnatzeachWord: string;
+    lamnatzeachLetter: string;
   };
   molad?: {
     hy: number;
@@ -207,6 +210,9 @@ export function eventToClassicApiObject(
         translit: omerEv.sefira('translit'),
         en: omerEv.sefira('en'),
       },
+      anaBekoachWord: omerEv.getAnaBekoachWord(),
+      lamnatzeachWord: omerEv.getLamnatzeachWord(),
+      lamnatzeachLetter: omerEv.getLamnatzeachLetter(),
     };
   }
   if (mask & flags.MOLAD) {

--- a/test/classic-rest-api.spec.js
+++ b/test/classic-rest-api.spec.js
@@ -530,6 +530,9 @@ test('omer', () => {
         he: 'נֶּֽצַח שֶׁבְּמַלְכוּת',
         translit: 'Netzach sheb\'Malkhut',
       },
+      anaBekoachWord: 'צַעֲקָתֵנוּ',
+      lamnatzeachWord: 'אוֹתוֹ',
+      lamnatzeachLetter: 'ם',
     },
   };
   expect(obj).toEqual(expected);

--- a/test/csv.spec.js
+++ b/test/csv.spec.js
@@ -19,9 +19,9 @@ test('eventToCsv', () => {
   const csv = events.map((e) => eventToCsv(e, options));
   expect(csv[0]).toBe(`"Candle lighting","4/6/1990","7:04 PM","4/6/1990","7:04 PM","false","","4","Chicago"`);
   expect(csv[1]).toBe(`"Havdalah","4/7/1990","8:06 PM","4/7/1990","8:06 PM","false","","4","Chicago"`);
-  expect(csv[2]).toBe(`"Erev Pesach","4/9/1990",,,,"true","Passover; the Feast of Unleavened Bread","3","Jewish Holidays"`);
-  expect(csv[3]).toBe(`"Candle lighting","4/9/1990","7:07 PM","4/9/1990","7:07 PM","false","Erev Pesach","4","Chicago"`);
-  expect(csv[4]).toBe(`"Pesach I","4/10/1990",,,,"true","Passover; the Feast of Unleavened Bread","4","Jewish Holidays"`);
+  expect(csv[2]).toBe(`"Biur Chametz","4/9/1990","11:47 AM","4/9/1990","11:47 AM","false","Erev Pesach","4","Chicago"`);
+  expect(csv[3]).toBe(`"Erev Pesach","4/9/1990",,,,"true","Passover; the Feast of Unleavened Bread","3","Jewish Holidays"`);
+  expect(csv[4]).toBe(`"Candle lighting","4/9/1990","7:07 PM","4/9/1990","7:07 PM","false","Erev Pesach","4","Chicago"`);
 });
 
 test('eventsToCsv', () => {

--- a/test/fullcalendar.spec.js
+++ b/test/fullcalendar.spec.js
@@ -36,6 +36,14 @@ test('eventToFullCalendar', () => {
       className: 'havdalah',
     },
     {
+      title: 'Biur Chametz',
+      start: '1990-04-09T11:47:00-05:00',
+      allDay: false,
+      hebrew: 'Biur Chametz',
+      className: 'zmanim biurChametz',
+      description: 'Erev Pesach',
+    },
+    {
       title: 'Erev Pesach',
       start: '1990-04-09',
       allDay: true,
@@ -92,16 +100,8 @@ test('eventToFullCalendar', () => {
       url: expectedUrl,
       description: pesachMemo,
     },
-    {
-      title: 'Pesach IV (CH’’M)',
-      start: '1990-04-13',
-      allDay: true,
-      hebrew: 'פסח ד׳ (חוה״מ)',
-      className: 'holiday major cholhamoed',
-      url: expectedUrl,
-      description: pesachMemo,
-    },
   ];
+
   expect(fc).toEqual(expected);
 });
 

--- a/test/rss.spec.js
+++ b/test/rss.spec.js
@@ -80,7 +80,7 @@ test('eventToRssItem2', () => {
     havdalahMins: 50,
     location: location,
   };
-  const events = HebrewCalendar.calendar(options).slice(0, 3);
+  const events = HebrewCalendar.calendar(options).slice(0, 4);
   options.evPubDate = true;
   options.lastBuildDate = 'Mon, 22 Jun 2020 20:03:18 GMT';
   options.mainUrl = 'https://www.hebcal.com/shabbat?city=Eilat';
@@ -104,6 +104,14 @@ test('eventToRssItem2', () => {
     '<description>Saturday, April 07, 1990</description>\n' +
     '<category>havdalah</category>\n' +
     '<pubDate>Sat, 07 Apr 1990 16:53:00 GMT</pubDate>\n' +
+    '</item>\n',
+    '<item>\n' +
+    '<title>Biur Chametz: 11:38</title>\n' +
+    '<link>https://www.hebcal.com/shabbat?city=Eilat&amp;dt=1990-04-09&amp;i=on&amp;utm_source=shabbat1c&amp;utm_medium=rss#19900409-biur-chametz</link>\n' +
+    '<guid isPermaLink="false">https://www.hebcal.com/shabbat?city=Eilat&amp;dt=1990-04-09#19900409-biur-chametz</guid>\n' +
+    '<description>Monday, April 09, 1990</description>\n' +
+    '<category>zmanim</category>\n' +
+    '<pubDate>Mon, 09 Apr 1990 08:38:00 GMT</pubDate>\n' +
     '</item>\n',
     '<item>\n' +
     '<title>Erev Pesach</title>\n' +


### PR DESCRIPTION
## Summary
This PR adds support for the Biur Chametz (burning of leavened bread) event and exposes additional Omer-related word data through the Classic REST API.

## Key Changes
- **New Event**: Added Biur Chametz as a timed zmanim event on Erev Pesach with description linking to the holiday
- **Omer API Enhancement**: Extended the Classic REST API omer object to include three new fields:
  - `anaBekoachWord`: The word of the day from the Ana B'Koach acrostic
  - `lamnatzeachWord`: The word of the day from the Lamnatzea acrostic
  - `lamnatzeachLetter`: The letter of the day from the Lamnatzea acrostic
- **Dependency Update**: Updated `@hebcal/core` from `^6.1.0` to `^6.3.0` to support the new Biur Chametz event and Omer word methods
- **Test Updates**: Updated test expectations in fullcalendar, RSS, CSV, and classic-rest-api specs to reflect the new event and API fields

## Implementation Details
- Biur Chametz appears as a separate timed event before Erev Pesach in calendar outputs
- The event includes proper classification (`zmanim biurChametz`) and description metadata
- Omer word data is only populated when the event is an Omer day, maintaining backward compatibility

https://claude.ai/code/session_01FsfqhwGex3f7FMzhDkhuoV