### PR TITLE
Add tachanun field to API output

### DIFF
--- a/src/classic-rest-api.ts
+++ b/src/classic-rest-api.ts
@@ -5,8 +5,10 @@ import {version} from '@hebcal/core/dist/esm/pkgVersion';
 import {Locale} from '@hebcal/core/dist/esm/locale';
 import {MoladEvent} from '@hebcal/core/dist/esm/molad';
 import {OmerEvent} from '@hebcal/core/dist/esm/omer';
+import {TachanunResult} from '@hebcal/core/dist/esm/tachanun';
 import {TimedEvent} from '@hebcal/core/dist/esm/TimedEvent';
 import {reformatTimeStr} from '@hebcal/core/dist/esm/reformatTimeStr';
+import {HebrewCalendar} from '@hebcal/core';
 import {AliyotMap, Leyning, StringMap} from '@hebcal/leyning/dist/esm/types';
 import {formatAliyahWithBook} from '@hebcal/leyning/dist/esm/common';
 import {getLeyningForParshaHaShavua} from '@hebcal/leyning/dist/esm/leyning';
@@ -72,6 +74,7 @@ export type ClassicApiResult = {
   date: string;
   version: string;
   location: LocationPlainObj;
+  tachanun?: TachanunResult;
   range?: {
     start: string;
     end: string;
@@ -113,6 +116,12 @@ export function eventsToClassicApiHeader(
       start: eventIsoDate(events[0]),
       end: eventIsoDate(events[events.length - 1]),
     };
+    if (options.tachanun && result.range.start === result.range.end) {
+      result.tachanun = HebrewCalendar.tachanun(
+        events[0].getDate(),
+        Boolean(options.il)
+      );
+    }
   }
   return result;
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -10,6 +10,7 @@ export type RestApiEventOptions = {
   utmSource?: string;
   utmMedium?: string;
   utmCampaign?: string;
+  tachanun?: boolean;
   appendHebrewToSubject?: boolean;
   yahrzeit?: boolean;
   subscribe?: string | number | boolean;

--- a/test/classic-rest-api.spec.js
+++ b/test/classic-rest-api.spec.js
@@ -150,6 +150,21 @@ test('eventsToClassicApi', () => {
   expect(candleLighting).toEqual(candleLightingExpected);
 });
 
+test('eventsToClassicApi tachanun', () => {
+  const options = {
+    start: new Date(2026, 4, 21),
+    end: new Date(2026, 4, 21),
+    tachanun: true,
+  };
+  const events = HebrewCalendar.calendar(options);
+  const apiResult = eventsToClassicApi(events, options);
+  expect(apiResult.tachanun).toEqual({
+    shacharit: false,
+    mincha: false,
+    allCongs: false,
+  });
+});
+
 test('classic-api-no-sedra', () => {
   const options = {start: new Date(2022, 4, 15), end: new Date(2022, 5, 1), il: true};
   const events = HebrewCalendar.calendar(options);


### PR DESCRIPTION
The purpose of the pull request is to expose the existing `@hebcal/core` tachanun calculation in `@hebcal/rest-api`

I thought it would be useful if this was available so people who make use of this service can also know when tachanun is said. Here are some example outputs:

Diaspora, **January 2, 2026** (`2026-01-02`, Friday before Shabbat):

```
"tachanun": {
  "shacharit": true,
  "mincha": false,
  "allCongs": true
}
```


Diaspora, **June 1, 2026** (`2026-06-01`, ordinary weekday):

```
"tachanun": {
  "shacharit": true,
  "mincha": true,
  "allCongs": true
}
```

Scope: add optional top-level `tachanun` field when `options.tachanun` is true and the response covers a single day
Test coverage: added formatter test for `2026-05-21`